### PR TITLE
Upgraded the react native version to 0.25^ and fixed warnings

### DIFF
--- a/example/ViewPager.js
+++ b/example/ViewPager.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import React, {
-  Component,
+import React, {Component} from 'react';
+import {
   StyleSheet,
   Text,
   View,

--- a/example/index.android.js
+++ b/example/index.android.js
@@ -3,9 +3,9 @@
  * https://github.com/facebook/react-native
  */
 'use strict';
-import React, {
+import React, {Component} from 'react';
+import {
   AppRegistry,
-  Component,
   StyleSheet,
   Text,
   ScrollView,
@@ -18,7 +18,7 @@ import React, {
 
 import Image from 'react-native-image-zoom'
 import ViewPager from './ViewPager'
-import {Actions, Router, Route, Schema, Animations, TabBar} from 'react-native-router-flux'
+import {Actions, Router, Scene, Schema, Animations, TabBar} from 'react-native-router-flux'
 
 class Example extends Component {
   constructor(a,b){
@@ -65,8 +65,10 @@ class main extends Component{
   render(){
     return (
       <Router hideNavBar={true}>
-        <Route name="Main" component={Example}/>
-        <Route name="ViewPager" component={ViewPager}/>
+        <Scene key="root">
+            <Scene key="Main" component={Example}/>
+            <Scene key="ViewPager" component={ViewPager}/>
+        </Scene>
       </Router>
     )
   }

--- a/example/index.ios.js
+++ b/example/index.ios.js
@@ -3,9 +3,9 @@
  * https://github.com/facebook/react-native
  */
 'use strict';
-import React, {
+import React, {Component} from 'react';
+import {
   AppRegistry,
-  Component,
   StyleSheet,
   Image,
   ScrollView,

--- a/example/package.json
+++ b/example/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "lodash": "^4.11.2",
     "react": "^0.14.8",
-    "react-native": "^0.23.0",
+    "react-native": "^0.25.1",
     "react-native-image-zoom": "../.",
-    "react-native-router-flux": "^2.3.8"
+    "react-native-router-flux": "^3.26.0"
   }
 }

--- a/index.android.js
+++ b/index.android.js
@@ -1,8 +1,7 @@
 
-import React,{
+import React,{Component,PropTypes} from 'react';
+import {
   requireNativeComponent,
-  Component,
-  PropTypes,
   View,
 } from 'react-native';
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,7 +1,6 @@
-
-import React,{
+import React,{Component} from 'react';
+import {
   View,
-  Component,
   ScrollView,
   Image
 } from 'react-native';

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   },
   "homepage": "https://github.com/Anthonyzou/react-native-image-zoom#readme",
   "dependencies": {
+  },
+  "peerDependencies": {
+    "react": "^0.14.8",
+    "react-native": "^0.25.1"
   }
 }


### PR DESCRIPTION
From version 0.25^ onwards, the core packages ( React, Component, PropTypes ..etc ) should be loaded from `React`. This is a breaking change in react-native version 0.26

Also Updated the examples to use the latest `react-native-router-flux`
