### PR TITLE
Expose Photoview MatrixChange event

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 | scaleType | string | null | one of center, centerCrop, centerInside, fitCenter, fitStart, fitEnd, fitXY, matrix|
 | onTap | function | null | optional on tap listener |
 | onLoad | function | null | optional on load listener |
+| onScaleChange | function | null | optional on scale change listener |
+| onMatrixChange | function | null | (Android only) optional on matrix change listener |
 
 ## Example
 

--- a/android/src/main/java/com/image/zoom/ImageEvent.java
+++ b/android/src/main/java/com/image/zoom/ImageEvent.java
@@ -24,13 +24,14 @@ class ImageEvent extends Event<ImageEvent> {
  */
 
 
-    @IntDef({ON_TAP, ON_LOAD, ON_SCALE})
+    @IntDef({ON_TAP, ON_LOAD, ON_SCALE, ON_MATRIX})
     @Retention(RetentionPolicy.SOURCE)
     @interface ImageEventType {}
 
     public static final int ON_TAP = 1;
     public static final int ON_LOAD = 2;
     public static final int ON_SCALE = 3;
+    public static final int ON_MATRIX = 4;
 
     private final int mEventType;
 
@@ -47,6 +48,8 @@ class ImageEvent extends Event<ImageEvent> {
                 return "topLoad";
             case ON_SCALE:
                 return "topScale";
+            case ON_MATRIX:
+                return "topMatrix";
             default:
                 throw new IllegalStateException("Invalid image event: " + Integer.toString(eventType));
         }

--- a/android/src/main/java/com/image/zoom/ViewManager.java
+++ b/android/src/main/java/com/image/zoom/ViewManager.java
@@ -1,5 +1,6 @@
 package com.image.zoom;
 
+import android.graphics.RectF;
 import android.net.Uri;
 import android.os.SystemClock;
 import android.util.Base64;
@@ -186,6 +187,24 @@ public class ViewManager extends SimpleViewManager<PhotoView> {
                 );
             }
         });
+
+        view.setOnMatrixChangeListener(new PhotoViewAttacher.OnMatrixChangedListener() {
+            @Override
+            public void onMatrixChanged(RectF rect) {
+                WritableMap rectMap = Arguments.createMap();
+                rectMap.putDouble("top", rect.top);
+                rectMap.putDouble("right", rect.right);
+                rectMap.putDouble("bottom", rect.bottom);
+                rectMap.putDouble("left", rect.left);
+                rectMap.putDouble("height", rect.height());
+                rectMap.putDouble("width", rect.width());
+                rectMap.putDouble("scale", view.getScale());
+                mEventDispatcher.dispatchEvent(
+                        new ImageEvent(view.getId(), SystemClock.uptimeMillis(), ImageEvent.ON_MATRIX)
+                        .setExtras(rectMap)
+                );
+            }
+        });
     }
 
     @Override
@@ -194,7 +213,8 @@ public class ViewManager extends SimpleViewManager<PhotoView> {
         return MapBuilder.of(
                 ImageEvent.eventNameForType(ImageEvent.ON_TAP), MapBuilder.of("registrationName", "onTap"),
                 ImageEvent.eventNameForType(ImageEvent.ON_LOAD), MapBuilder.of("registrationName", "onLoad"),
-                ImageEvent.eventNameForType(ImageEvent.ON_SCALE), MapBuilder.of("registrationName", "onScaleChange")
+                ImageEvent.eventNameForType(ImageEvent.ON_SCALE), MapBuilder.of("registrationName", "onScaleChange"),
+                ImageEvent.eventNameForType(ImageEvent.ON_MATRIX), MapBuilder.of("registrationName", "onMatrixChange")
         );
     }
 

--- a/index.android.js
+++ b/index.android.js
@@ -25,6 +25,7 @@ export default class ImageViewZoom extends Component {
     onTap : PropTypes.func,
     onLoad : PropTypes.func,
     onScaleChange : PropTypes.func,
+    onMatrixChange : PropTypes.func,
   };
 
   constructor(props) {


### PR DESCRIPTION
Here is a patch that exposes the matrixChange event from Photoview. It has the advantage of being triggered on drag rather than just on scale change. I also took the liberty of adding `scale` in the event properties as I find it very useful.
