### PR TITLE
Use centerContent instead in iOS component

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -12,7 +12,7 @@ export default class ImageViewZoom extends Component {
         <ScrollView
           maximumZoomScale={this.props.maximumZoomScale}
           minimumZoomScale={this.props.minimumZoomScale}
-          contentContainerStyle={{ alignItems:'center', justifyContent:'center'}}>
+          centerContent
           <Image {...this.props}/>
         </ScrollView>
       </View>


### PR DESCRIPTION
Defining a style doesn't work in some cases, but the centerContent property which is iOS only works like a charm.
