### PR TITLE
Fixing orientation changes handling (responsive images)

### DIFF
--- a/android/src/main/java/com/image/zoom/PhotoViewWrapper.java
+++ b/android/src/main/java/com/image/zoom/PhotoViewWrapper.java
@@ -1,0 +1,248 @@
+package com.image.zoom;
+
+import android.graphics.RectF;
+import android.net.Uri;
+import android.os.SystemClock;
+import android.util.Log;
+import android.util.Base64;
+import android.util.SparseArray;
+import android.view.View;
+
+import com.bumptech.glide.DrawableRequestBuilder;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.LazyHeaders;
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.target.Target;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import javax.annotation.Nullable;
+
+import uk.co.senab.photoview.PhotoView;
+import uk.co.senab.photoview.PhotoViewAttacher;
+
+
+public class PhotoViewWrapper extends PhotoView {
+
+    private EventDispatcher mEventDispatcher;
+    private ReadableMap mParams;
+    private SparseArray<Float> scales = new SparseArray<>();
+    private ResourceDrawableIdHelper mResourceDrawableIdHelper;
+    private boolean mInitialized = false;
+
+    public PhotoViewWrapper(ThemedReactContext context) {
+        super(context);
+        mEventDispatcher = context.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        mResourceDrawableIdHelper = new ResourceDrawableIdHelper();
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+
+        if (w > 0 && h > 0) {
+            setSource(mParams);
+        }
+    }
+
+    public void setSource(ReadableMap params) {
+        mParams = params;
+        @Nullable Uri mUri = null;
+
+        String source = params.hasKey("uri") ? params.getString("uri") : null;
+        String thumbnail = params.hasKey("thumbnail") ? params.getString("thumbnail") : null;
+        ReadableMap headers = params.hasKey("headers") ? params.getMap("headers") : null;
+
+        //handle base64
+        if (source.startsWith("data:image/png;base64,")){
+            Glide
+                .with(this.getContext())
+                .load(Base64.decode(source.replaceAll("data:image\\/.*;base64,", ""), Base64.DEFAULT))
+                .into(this)
+            ;
+            return;
+        }
+
+        boolean useStorageFile = false ;
+
+        // handle bundled app resources
+        try {
+            mUri = Uri.parse(source);
+            // Verify scheme is set, so that relative uri (used by static resources) are not handled.
+            if (mUri.getScheme() == null) {
+                mUri = null;
+            } else if(
+                !mUri.getScheme().equals("http") &&
+                !mUri.getScheme().equals("https")
+            ){
+                useStorageFile = true ;
+
+                if (!mInitialized) {
+                    this.setImageURI(mUri);
+                }
+            }
+        } catch (Exception e) {
+            // ignore malformed uri, then attempt to extract resource ID.
+        }
+
+        if (mUri == null) {
+            mUri = mResourceDrawableIdHelper.getResourceDrawableUri(
+                this.getContext(),
+                source
+            );
+            Glide
+                .with(this.getContext())
+                .load(mUri)
+                .into(this);
+        } else if (useStorageFile) {
+            Glide
+                .with(this.getContext())
+                .load(mUri)
+                .into(this);
+        } else {
+            // Handle an http / https address
+            RequestListener listener = this.getRequestListener();
+
+            LazyHeaders.Builder lazyHeaders = new LazyHeaders.Builder();
+            Log.d("null headers", String.valueOf(headers != null));
+            if(headers != null){
+                ReadableMapKeySetIterator it = headers.keySetIterator();
+                Log.d("next headers", String.valueOf(it.hasNextKey()));
+                while(it.hasNextKey()){
+                    String Key = it.nextKey();
+                    lazyHeaders.addHeader(Key, headers.getString(Key));
+                }
+            }
+
+            Log.d("thing", mUri.toString());
+            DrawableRequestBuilder builder = Glide
+                    .with(this.getContext())
+                    .load(new GlideUrl(mUri.toString(), lazyHeaders.build()))
+                    .listener(listener);
+
+            //set thumbnails
+            if(thumbnail != null) {
+                DrawableRequestBuilder<String> thumbnailRequest = Glide
+                        .with(this.getContext())
+                        .load(thumbnail);
+                builder = builder.thumbnail(thumbnailRequest);
+            }
+
+            builder.into(this);
+        }
+
+        this.setChangeListeners();
+    }
+
+    private RequestListener getRequestListener() {
+
+        return new RequestListener<GlideUrl, GlideDrawable>() {
+            @Override
+            public boolean onException(Exception e, GlideUrl model,
+                                       Target<GlideDrawable> target,
+                                       boolean isFirstResource) {
+                return false;
+            }
+
+            @Override
+            public boolean onResourceReady(GlideDrawable resource, GlideUrl model,
+                                           Target<GlideDrawable> target,
+                                           boolean isFromMemoryCache,
+                                           boolean isFirstResource) {
+                Float scale = scales.get(getId());
+                if (scale != null) {
+                    setScale(scale, true);
+                }
+
+                final int width = getWidth();
+                final int height = getHeight();
+
+                WritableMap map = Arguments.createMap();
+                map.putInt("height", height);
+                map.putInt("width", width);
+                mEventDispatcher.dispatchEvent(
+                    new ImageEvent(
+                        getId(),
+                        SystemClock.uptimeMillis(),
+                        ImageEvent.ON_LOAD
+                    )
+                    .setExtras(map)
+                );
+                return false;
+            }
+        };
+    }
+
+    private void setChangeListeners() {
+        if (mInitialized) {
+            return;
+        }
+        mInitialized = true;
+
+        this.setOnScaleChangeListener(new PhotoViewAttacher.OnScaleChangeListener() {
+            @Override
+            public void onScaleChange(float scaleFactor, float focusX, float focusY) {
+                WritableMap scaleChange = Arguments.createMap();
+                scaleChange.putDouble("scaleFactor", scaleFactor);
+                scaleChange.putDouble("focusX", focusX);
+                scaleChange.putDouble("focusY", focusY);
+                mEventDispatcher.dispatchEvent(
+                    new ImageEvent(
+                        getId(),
+                        SystemClock.uptimeMillis(),
+                        ImageEvent.ON_SCALE
+                    )
+                    .setExtras(scaleChange)
+                );
+            }
+        });
+
+        this.setOnViewTapListener(new PhotoViewAttacher.OnViewTapListener() {
+            @Override
+            public void onViewTap(View view, float x, float y) {
+                mEventDispatcher.dispatchEvent(
+                    new ImageEvent(
+                        view.getId(),
+                        SystemClock.uptimeMillis(),
+                        ImageEvent.ON_TAP
+                    )
+                );
+            }
+        });
+
+        this.setOnMatrixChangeListener(new PhotoViewAttacher.OnMatrixChangedListener() {
+            @Override
+            public void onMatrixChanged(RectF rect) {
+                WritableMap rectMap = Arguments.createMap();
+                rectMap.putDouble("top", rect.top);
+                rectMap.putDouble("right", rect.right);
+                rectMap.putDouble("bottom", rect.bottom);
+                rectMap.putDouble("left", rect.left);
+                rectMap.putDouble("height", rect.height());
+                rectMap.putDouble("width", rect.width());
+                rectMap.putDouble("scale", getScale());
+                mEventDispatcher.dispatchEvent(
+                    new ImageEvent(
+                        getId(),
+                        SystemClock.uptimeMillis(),
+                        ImageEvent.ON_MATRIX
+                    )
+                    .setExtras(rectMap)
+                );
+            }
+        });
+    }
+
+    public void setCustomScale(@Nullable float scale) {
+        scales.put(getId(), scale);
+        setScale(scale);
+    }
+
+}

--- a/android/src/main/java/com/image/zoom/ViewManager.java
+++ b/android/src/main/java/com/image/zoom/ViewManager.java
@@ -1,53 +1,23 @@
 package com.image.zoom;
 
-import android.graphics.RectF;
-import android.net.Uri;
-import android.os.SystemClock;
-import android.util.Base64;
 import android.util.Log;
-import android.util.SparseArray;
-import android.view.View;
 import android.widget.ImageView.ScaleType;
 
-import com.bumptech.glide.DrawableRequestBuilder;
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.model.GlideUrl;
-import com.bumptech.glide.load.model.LazyHeaders;
-import com.bumptech.glide.load.resource.drawable.GlideDrawable;
-import com.bumptech.glide.request.RequestListener;
-import com.bumptech.glide.request.target.Target;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.EventDispatcher;
 
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import uk.co.senab.photoview.PhotoView;
-import uk.co.senab.photoview.PhotoViewAttacher;
 
 /**
  * Created by azou on 15/02/16.
  */
-public class ViewManager extends SimpleViewManager<PhotoView> {
-    private PhotoView photoView;
-    private EventDispatcher mEventDispatcher;
-
-    private SparseArray<Float> scales = new SparseArray<>();
-
-    private ResourceDrawableIdHelper mResourceDrawableIdHelper;
-
-    public ViewManager() {
-        mResourceDrawableIdHelper = new ResourceDrawableIdHelper();
-    }
+public class ViewManager extends SimpleViewManager<PhotoViewWrapper> {
 
     @Override
     public String getName() {
@@ -55,178 +25,28 @@ public class ViewManager extends SimpleViewManager<PhotoView> {
     }
 
     @Override
-    public PhotoView createViewInstance(ThemedReactContext reactContext) {
-        photoView = new PhotoView(reactContext);
-        mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-        return photoView;
+    public PhotoViewWrapper createViewInstance(ThemedReactContext reactContext) {
+        return new PhotoViewWrapper(reactContext);
     }
 
-
-
     @ReactProp(name = "src")
-    public void setSource(final PhotoView view, ReadableMap params) {
-        @Nullable Uri mUri = null;
-        String source = params.hasKey("uri") ? params.getString("uri") : null;
-        String thumbnail = params.hasKey("thumbnail") ? params.getString("thumbnail") : null;
-        ReadableMap headers = params.hasKey("headers") ? params.getMap("headers") : null;
-
-        RequestListener listener = new RequestListener<GlideUrl, GlideDrawable>() {
-            @Override
-            public boolean onException(Exception e, GlideUrl model,
-                                       Target<GlideDrawable> target,
-                                       boolean isFirstResource) {
-                return false;
-            }
-
-            @Override
-            public boolean onResourceReady(GlideDrawable resource, GlideUrl model,
-                                           Target<GlideDrawable> target,
-                                           boolean isFromMemoryCache,
-                                           boolean isFirstResource) {
-                Float scale = scales.get(view.getId());
-                if(scale != null) {
-                    view.setScale(scale, true);
-                }
-
-                final int width = view.getWidth();
-                final int height = view.getHeight();
-
-                WritableMap map = Arguments.createMap();
-                map.putInt("height", height);
-                map.putInt("width", width);
-                mEventDispatcher.dispatchEvent(
-                        new ImageEvent(view.getId(), SystemClock.uptimeMillis(), ImageEvent.ON_LOAD)
-                        .setExtras(map)
-                );
-                return false;
-            }
-        };
-
-        //handle base64
-        if (source.startsWith("data:image/png;base64,")){
-            Glide
-                    .with(view.getContext())
-                    .load(Base64.decode(source.replaceAll("data:image\\/.*;base64,", ""), Base64.DEFAULT))
-                    .into(view)
-            ;
-            return;
-        }
-        
-        boolean useStorageFile = false ;
-
-        // handle bundled app resources
-        try {
-            mUri = Uri.parse(source);
-            // Verify scheme is set, so that relative uri (used by static resources) are not handled.
-            if (mUri.getScheme() == null) {
-                mUri = null;
-            }else if(!mUri.getScheme().equals("http") && !mUri.getScheme().equals("https")){
-                useStorageFile = true ;
-                view.setImageURI(mUri);
-            }
-        } catch (Exception e) {
-            // ignore malformed uri, then attempt to extract resource ID.
-        }
-
-        if (mUri == null) {
-            mUri = mResourceDrawableIdHelper.getResourceDrawableUri(view.getContext(), source);
-            Glide
-                    .with(view.getContext())
-                    .load(mUri)
-                    .into(view)
-            ;
-        }else if(useStorageFile){
-            Glide.with(view.getContext()).load(mUri).into(view) ;
-        }else {
-            // Handle an http address
-
-            // Add http headers
-            LazyHeaders.Builder lazyHeaders = new LazyHeaders.Builder();
-            Log.d("null headers", String.valueOf(headers != null));
-            if(headers != null){
-                ReadableMapKeySetIterator it = headers.keySetIterator();
-                Log.d("next headers", String.valueOf(it.hasNextKey()));
-                while(it.hasNextKey()){
-                    String Key = it.nextKey();
-
-                    lazyHeaders.addHeader(Key, headers.getString(Key));
-                }
-            }
-
-            Log.d("thing", mUri.toString());
-            DrawableRequestBuilder builder = Glide
-                    .with(view.getContext())
-                    .load(new GlideUrl(mUri.toString(), lazyHeaders.build()))
-                    .listener(listener)
-                    ;
-
-            //set thumbnails
-            if(thumbnail != null) {
-
-                DrawableRequestBuilder<String> thumbnailRequest = Glide
-                        .with(view.getContext())
-                        .load( thumbnail );
-                builder = builder.thumbnail(thumbnailRequest);
-            }
-
-            builder.into(view);
-        }
-
-        view.setOnScaleChangeListener(new PhotoViewAttacher.OnScaleChangeListener() {
-            @Override
-            public void onScaleChange(float scaleFactor, float focusX, float focusY) {
-                WritableMap scaleChange = Arguments.createMap();
-                scaleChange.putDouble("scaleFactor", scaleFactor);
-                scaleChange.putDouble("focusX", focusX);
-                scaleChange.putDouble("focusY", focusY);
-                mEventDispatcher.dispatchEvent(
-                        new ImageEvent(view.getId(), SystemClock.uptimeMillis(), ImageEvent.ON_SCALE)
-                        .setExtras(scaleChange)
-                );
-            }
-        });
-
-        view.setOnViewTapListener(new PhotoViewAttacher.OnViewTapListener() {
-            @Override
-            public void onViewTap(View view, float x, float y) {
-                mEventDispatcher.dispatchEvent(
-                        new ImageEvent(view.getId(), SystemClock.uptimeMillis(), ImageEvent.ON_TAP)
-                );
-            }
-        });
-
-        view.setOnMatrixChangeListener(new PhotoViewAttacher.OnMatrixChangedListener() {
-            @Override
-            public void onMatrixChanged(RectF rect) {
-                WritableMap rectMap = Arguments.createMap();
-                rectMap.putDouble("top", rect.top);
-                rectMap.putDouble("right", rect.right);
-                rectMap.putDouble("bottom", rect.bottom);
-                rectMap.putDouble("left", rect.left);
-                rectMap.putDouble("height", rect.height());
-                rectMap.putDouble("width", rect.width());
-                rectMap.putDouble("scale", view.getScale());
-                mEventDispatcher.dispatchEvent(
-                        new ImageEvent(view.getId(), SystemClock.uptimeMillis(), ImageEvent.ON_MATRIX)
-                        .setExtras(rectMap)
-                );
-            }
-        });
+    public void setSource(final PhotoViewWrapper view, ReadableMap params) {
+        view.setSource(params);
     }
 
     @Override
     public @Nullable
     Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.of(
-                ImageEvent.eventNameForType(ImageEvent.ON_TAP), MapBuilder.of("registrationName", "onTap"),
-                ImageEvent.eventNameForType(ImageEvent.ON_LOAD), MapBuilder.of("registrationName", "onLoad"),
-                ImageEvent.eventNameForType(ImageEvent.ON_SCALE), MapBuilder.of("registrationName", "onScaleChange"),
-                ImageEvent.eventNameForType(ImageEvent.ON_MATRIX), MapBuilder.of("registrationName", "onMatrixChange")
+            ImageEvent.eventNameForType(ImageEvent.ON_TAP), MapBuilder.of("registrationName", "onTap"),
+            ImageEvent.eventNameForType(ImageEvent.ON_LOAD), MapBuilder.of("registrationName", "onLoad"),
+            ImageEvent.eventNameForType(ImageEvent.ON_SCALE), MapBuilder.of("registrationName", "onScaleChange"),
+            ImageEvent.eventNameForType(ImageEvent.ON_MATRIX), MapBuilder.of("registrationName", "onMatrixChange")
         );
     }
 
     @ReactProp(name = "tintColor", customType = "Color")
-    public void setTintColor(PhotoView view, @Nullable Integer tintColor) {
+    public void setTintColor(PhotoViewWrapper view, @Nullable Integer tintColor) {
         if (tintColor == null) {
             view.clearColorFilter();
         } else {
@@ -235,13 +55,12 @@ public class ViewManager extends SimpleViewManager<PhotoView> {
     }
 
     @ReactProp(name = "scale")
-    public void setScale(PhotoView view, @Nullable float scale) {
-        scales.put(view.getId(), scale);
-        view.setScale(scale);
+    public void setScale(PhotoViewWrapper view, @Nullable float scale) {
+        view.setCustomScale(scale);
     }
 
     @ReactProp(name = "scaleType")
-    public void setScaleType(PhotoView view, String scaleType) {
+    public void setScaleType(PhotoViewWrapper view, String scaleType) {
         ScaleType value = ScaleType.CENTER;
 
         switch (scaleType) {
@@ -271,7 +90,7 @@ public class ViewManager extends SimpleViewManager<PhotoView> {
                 break;
         }
 
-        photoView.setScaleType(value);
+        view.setScaleType(value);
     }
 
 }


### PR DESCRIPTION
Hi Anthony,

First, thanks for releasing react-native-image-zoom. I found it a couple days ago and it rocks, it's exactly what I was looking for. I really like the pinch-and-zoom and panning performance PhotoView and its bridge have.

However, I found a little bug. I'm working on a new RN app and I want it to work in both modes: PORTRAIT and LANDSCAPE. I have a view that shows 2 images side by side (each one fills half the screen), and when the device is rotated the width of both images gets recalculated and passed to their `style`. 

This wasn't working correctly, so I decided to have a go at finding a fix, which honestly has been quite hard due to the lack of documentation on how to write native modules in RN.

I've recorded a couple gifs that illustrate the bug. As you can see, once the device is rotated images don't get the right size and redrawn correctly. Then when the device is rotated again back to its original position, the sizes don't match the first ones:
<img src="http://g.recordit.co/Ru3Lfk2KFw.gif" />

And the current behavior with my patch is:
<img src="http://g.recordit.co/ilVBgyKsJJ.gif" />

The commit message has some explanation on what I've done. I've heavily inspired my solution in React Native code itself: <a href="https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java">ReactImageView</a> and <a href="https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java">ReactImageManager</a>

I've also moved some initialization code to two different methods, because setSource was a little big to digest.

Let me know any questions you've got, cheers
Miguel
